### PR TITLE
changed build.sbt to work with play 2.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,12 +10,12 @@ resolvers ++= Seq(
   "Mandubian repository releases" at "https://github.com/mandubian/mandubian-mvn/raw/master/releases/"
 )
 
-scalaVersion := "2.10.2"
+scalaVersion := "2.11.1"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play"   %% "play-json"  % "2.2.0"          ,
-  "org.specs2"          %% "specs2"     % "1.13"   % "test",
-  "junit"                % "junit"      % "4.8"    % "test"
+  "com.typesafe.play"   %% "play-json"  % "2.3.0"          ,
+  "org.specs2"          %% "specs2"     % "2.3.12"   % "test",
+  "junit"                % "junit"      % "4.11"    % "test"
 )
 
 publishMavenStyle := true


### PR DESCRIPTION
Hy Pascal

This seems to work for me. 

After modifying `build.sbt`, I run `sbt reload`,`sbt compile`,`sbt package` and copied the generated `play-json-zipper_2.11-1.1.jar` to the `libs` folder in my project... 

Please write me, when you upload the modified project to bintray, so I can replace `play-json-zipper_2.11-1.1.jar` with your managed dependency... 
